### PR TITLE
fix: resolve all ESLint errors blocking Vercel CI build

### DIFF
--- a/client/src/components/auth/Login.js
+++ b/client/src/components/auth/Login.js
@@ -330,7 +330,7 @@ const Login = (props) => {
     } else {
       window.onGoogleLibraryLoad = initGAuth;
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   //for password to show
   const [showPassword, setShowPassword] = useState(false);

--- a/client/src/components/auth/Signup.js
+++ b/client/src/components/auth/Signup.js
@@ -55,7 +55,7 @@ const Signup = (props) => {
     } else {
       window.onGoogleLibraryLoad = initGAuth;
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   /////////////////////////////////////////////gooogle end//////////////////////////////////////////////////////////////////////
 

--- a/client/src/components/chats/Chatbox.jsx
+++ b/client/src/components/chats/Chatbox.jsx
@@ -6,16 +6,7 @@ import { UserContext } from "../../context/UserContext.jsx";
 
 const Chatbox = ({ fetchAgain, setFetchAgain }) => {
   const {
-    islogin,
-    setIslogin,
     selectedChat,
-    setSelectedChat,
-    user,
-    setUser,
-    notification,
-    setNotification,
-    chats,
-    setChats,
   } = useContext(UserContext);
 
   return (

--- a/client/src/components/chats/MyChats.jsx
+++ b/client/src/components/chats/MyChats.jsx
@@ -1,11 +1,10 @@
-import { AddIcon } from "@chakra-ui/icons";
+import { BellIcon } from "@chakra-ui/icons";
 import { Box, Stack, Text } from "@chakra-ui/layout";
 import { useToast } from "@chakra-ui/toast";
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { getSender } from "./config/ChatLogics";
 import ChatLoading from "./ChatLoading";
-import GroupChatModal from "./miscellaneous/GroupChatModal";
 import { Button } from "@chakra-ui/react";
 import { useContext } from "react";
 import { UserContext } from "../../context/UserContext.jsx";
@@ -15,14 +14,10 @@ import { useDisclosure } from "@chakra-ui/hooks";
 import { Input } from "@chakra-ui/input";
 import UserListItem from "./userAvatar/UserListItem";
 import { Spinner } from "@chakra-ui/spinner";
-import ProfileModal from "./miscellaneous/ProfileModal";
 import { Badge } from "@chakra-ui/react";
-import { BellIcon, ChevronDownIcon } from "@chakra-ui/icons";
-import { Avatar } from "@chakra-ui/avatar";
 import {
   Menu,
   MenuButton,
-  MenuDivider,
   MenuItem,
   MenuList,
 } from "@chakra-ui/menu";
@@ -46,14 +41,11 @@ const MyChats = ({ fetchAgain }) => {
   const {
     loggedUser,
     setLoggedUser,
-    islogin,
-    setIslogin,
     selectedChat,
     setSelectedChat,
     searchResult,
     setSearchResult,
     user,
-    setUser,
     notification,
     setNotification,
     chats,
@@ -168,7 +160,7 @@ const MyChats = ({ fetchAgain }) => {
     const raw = localStorage.getItem("userInfo");
     if (raw) setLoggedUser(JSON.parse(raw));
     fetchChats();
-  }, [fetchAgain]);
+  }, [fetchAgain]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>

--- a/client/src/components/chats/ScrollableChat.jsx
+++ b/client/src/components/chats/ScrollableChat.jsx
@@ -9,20 +9,9 @@ import {
 } from "./config/ChatLogics";
 import { useContext } from "react";
 import { UserContext } from "../../context/UserContext.jsx";
-import {url} from "../../utils/Constants";
-
 const ScrollableChat = ({ messages }) => {
   const {
-    islogin,
-    setIslogin,
-    selectedChat,
-    setSelectedChat,
     user,
-    setUser,
-    notification,
-    setNotification,
-    chats,
-    setChats,
   } = useContext(UserContext);
 
   return (

--- a/client/src/components/chats/SingleChat.jsx
+++ b/client/src/components/chats/SingleChat.jsx
@@ -32,16 +32,11 @@ const SingleChat = ({ fetchAgain, setFetchAgain }) => {
   const socketRef = useRef(null);
 
   const {
-    islogin,
-    setIslogin,
     selectedChat,
     setSelectedChat,
     user,
-    setUser,
     notification,
     setNotification,
-    chats,
-    setChats,
   } = useContext(UserContext);
 
   const defaultOptions = {
@@ -157,7 +152,7 @@ const SingleChat = ({ fetchAgain, setFetchAgain }) => {
   useEffect(() => {
     fetchMessages();
     selectedChatCompare = selectedChat;
-  }, [selectedChat]);
+  }, [selectedChat]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!socketRef.current) return;
@@ -180,7 +175,7 @@ const SingleChat = ({ fetchAgain, setFetchAgain }) => {
     return () => {
       socketRef.current.off("message recieved", handler);
     };
-  }, [notification]);
+  }, [notification]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>

--- a/client/src/components/chats/chatpages/Chatpage.jsx
+++ b/client/src/components/chats/chatpages/Chatpage.jsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import Chatbox from "../Chatbox";
 import MyChats from "../MyChats";
 import { useNavigate } from "react-router-dom";
-import swal from "sweetalert";
 // import SideDrawer from "../miscellaneous/SideDrawer";
 import { useContext , useEffect } from "react";
 import { UserContext } from "../../../context/UserContext.jsx";
@@ -13,15 +12,7 @@ const Chatpage = () => {
   const [fetchAgain, setFetchAgain] = useState(false);
   const {
     islogin,
-    setIslogin,
-    selectedChat,
-    setSelectedChat,
     user,
-    setUser,
-    notification,
-    setNotification,
-    chats,
-    setChats,
   } = useContext(UserContext);
 
   const navigate=useNavigate();
@@ -30,7 +21,7 @@ const Chatpage = () => {
     if (!islogin) {
       navigate("/login");
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <ChakraProvider>

--- a/client/src/components/chats/miscellaneous/GroupChatModal.jsx
+++ b/client/src/components/chats/miscellaneous/GroupChatModal.jsx
@@ -25,20 +25,12 @@ const GroupChatModal = ({ children }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [groupChatName, setGroupChatName] = useState();
   const [selectedUsers, setSelectedUsers] = useState([]);
-  const [search, setSearch] = useState("");
+  const [, setSearch] = useState("");
   const [searchResult, setSearchResult] = useState([]);
   const [loading, setLoading] = useState(false);
   const toast = useToast();
 
   const {
-    islogin,
-    setIslogin,
-    selectedChat,
-    setSelectedChat,
-    user,
-    setUser,
-    notification,
-    setNotification,
     chats,
     setChats,
   } = useContext(UserContext);

--- a/client/src/components/chats/miscellaneous/ProfileModal.jsx
+++ b/client/src/components/chats/miscellaneous/ProfileModal.jsx
@@ -1,5 +1,4 @@
 import { ViewIcon } from "@chakra-ui/icons";
-import {url} from "../../../utils/Constants";
 import {
   Modal,
   ModalOverlay,

--- a/client/src/components/chats/miscellaneous/UpdateGroupChatModal.jsx
+++ b/client/src/components/chats/miscellaneous/UpdateGroupChatModal.jsx
@@ -34,16 +34,9 @@ const UpdateGroupChatModal = ({ fetchMessages, fetchAgain, setFetchAgain }) => {
   const toast = useToast();
 
   const {
-    islogin,
-    setIslogin,
     selectedChat,
     setSelectedChat,
     user,
-    setUser,
-    notification,
-    setNotification,
-    chats,
-    setChats,
   } = useContext(UserContext);
 
   const handleSearch = async (query) => {

--- a/client/src/components/filter/Flat.jsx
+++ b/client/src/components/filter/Flat.jsx
@@ -12,7 +12,7 @@ function Flat() {
   const [flats, setFlats] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const { islogin, setIslogin, filterData, setFilterData } =
+  const { islogin, filterData, setFilterData } =
     useContext(UserContext);
   const navigate = useNavigate();
 
@@ -42,11 +42,6 @@ function Flat() {
     setFilter(cleared);
     setFilterData(cleared);
     setFilterDatas(cleared);
-  };
-
-  const removeFilter = async (f) => {
-    setFilterData({ ...filterData, [f]: "" });
-    setFilter({ ...filter, [f]: "" });
   };
 
   //for pagination
@@ -118,7 +113,7 @@ function Flat() {
 
   useEffect(() => {
     getData();
-  }, [currentPage, pageSize, filterDatas, sort]);
+  }, [currentPage, pageSize, filterDatas, sort]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const addtosaved = async (id) => {
     if (!islogin) {
@@ -279,8 +274,8 @@ function Flat() {
                         Sorry, there is no data available to display at the
                         moment.
                       </p>
-                      <a href="#"
-                        onClick={handleReset} className="btn btn-primary">
+                      <a href="#!"
+                        onClick={(e) => { e.preventDefault(); handleReset(e); }} className="btn btn-primary">
                         Remove All Filters
                       </a>
                     </div>

--- a/client/src/components/filter/Hotel.jsx
+++ b/client/src/components/filter/Hotel.jsx
@@ -13,7 +13,7 @@ function Hotel() {
   const [hotels, setHotels] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const {islogin,setIslogin,setFilterData,filterData} = useContext(UserContext);
+  const {islogin,setFilterData,filterData} = useContext(UserContext);
   const navigate = useNavigate();
 
   const [filter, setFilter] = useState({
@@ -42,11 +42,6 @@ function Hotel() {
     setFilter(cleared);
     setFilterData(cleared);
     setFilterDatas(cleared);
-  };
-
-  const removeFilter = async (f) => {
-    setFilterData({ ...filterData, [f]: "" });
-    setFilter({ ...filter, [f]: "" });
   };
 
   //for pagination
@@ -117,9 +112,9 @@ function Hotel() {
   setIsLoading(false);
   };
 
-  useEffect(() => {  
+  useEffect(() => {
     getData();
-  }, [currentPage, pageSize,filterDatas,sort]);
+  }, [currentPage, pageSize,filterDatas,sort]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const addtosaved = async (id) => {
     if (!islogin) {
@@ -275,8 +270,8 @@ function Hotel() {
                         Sorry, there is no data available to display at the
                         moment.
                       </p>
-                      <a href="#"
-                        onClick={handleReset} className="btn btn-primary">
+                      <a href="#!"
+                        onClick={(e) => { e.preventDefault(); handleReset(e); }} className="btn btn-primary">
                         Remove All Filters
                       </a>
                     </div>

--- a/client/src/components/filter/Room.jsx
+++ b/client/src/components/filter/Room.jsx
@@ -12,7 +12,7 @@ function Room() {
   const [rooms, setRooms] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const { islogin, setIslogin, setFilterData, filterData } =
+  const { islogin, setFilterData, filterData } =
     useContext(UserContext);
   const navigate = useNavigate();
 
@@ -42,11 +42,6 @@ function Room() {
     setFilter(cleared);
     setFilterData(cleared);
     setFilterDatas(cleared);
-  };
-
-  const removeFilter = async (f) => {
-    setFilterData({ ...filterData, [f]: "" });
-    setFilter({ ...filter, [f]: "" });
   };
 
   //for pagination
@@ -122,7 +117,7 @@ function Room() {
 
   useEffect(() => {
     getData();
-  }, [currentPage, pageSize, filterDatas, sort]);
+  }, [currentPage, pageSize, filterDatas, sort]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const addtosaved = async (id) => {
     if (!islogin) {
@@ -283,8 +278,8 @@ function Room() {
                         moment.
                       </p>
                       <a
-                        href="#"
-                        onClick={handleReset}
+                        href="#!"
+                        onClick={(e) => { e.preventDefault(); handleReset(e); }}
                         className="btn btn-primary"
                       >
                         Remove All Filters

--- a/client/src/components/home/CommonCards.jsx
+++ b/client/src/components/home/CommonCards.jsx
@@ -1,13 +1,11 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import "../../assets/styles/commoncards.css";
-import { AiOutlineRight } from "react-icons/ai";
-
 import { UserContext } from "../../context/UserContext.jsx";
 
 const CommonCards = ({ images, heading, content, type, link }) => {
 
-  const { setFilterData, filterData } = useContext(UserContext);
+  const { setFilterData } = useContext(UserContext);
   const navigate = useNavigate();
 
   const handleUpdatePlacetypeAddress = (link, addresses, placetypes) => {

--- a/client/src/components/home/FeaturedCards.jsx
+++ b/client/src/components/home/FeaturedCards.jsx
@@ -1,6 +1,5 @@
-import React, { useRef, useEffect,useState } from "react";
+import React, { useEffect,useState } from "react";
 import { Link } from "react-router-dom";
-import { MdArrowRightAlt, MdImageSearch } from "react-icons/md";
 import "../../assets/styles/featuredcards.css";
 
 import { Swiper, SwiperSlide } from "swiper/react";

--- a/client/src/components/home/Home.jsx
+++ b/client/src/components/home/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState } from "react";
 import CommonCards from "./CommonCards";
 import FeaturedCards from "./FeaturedCards";
 import SlidingBrands from "./SlidingBrands";

--- a/client/src/components/home/SlidingBrands.jsx
+++ b/client/src/components/home/SlidingBrands.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect,useState } from "react";
+import React, { useEffect,useState } from "react";
 import "../../assets/styles/slidingbrands.css";
 import "swiper/css";
 import { Swiper, SwiperSlide } from "swiper/react";

--- a/client/src/components/map/Map.jsx
+++ b/client/src/components/map/Map.jsx
@@ -18,7 +18,7 @@ const distanceToMouse = (pt, mp) => {
 export default function Map() {
   const [points, setPoints] = useState([]);
   const [isMapLoading, setIsMapLoading] = useState(true);
-  const { latitude, setLatitude, longitude, setLongitude } = useContext(UserContext);
+  const { setLatitude, setLongitude } = useContext(UserContext);
   const navigate = useNavigate();
   const [lastClickTime, setLastClickTime] = useState(0);
 

--- a/client/src/components/map/MyMarker.jsx
+++ b/client/src/components/map/MyMarker.jsx
@@ -1,7 +1,7 @@
 // export default MyMarker;
 
 import React, { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 const MyMarker = ({ text, tooltip, $hover, price, placetype, isbooked }) => {
   const [showInfo, setShowInfo] = useState(false);

--- a/client/src/components/profile/BookingWidget.jsx
+++ b/client/src/components/profile/BookingWidget.jsx
@@ -14,7 +14,7 @@ export default function BookingWidget({ place }) {
   const [phone, setPhone] = useState("");
   const [redirect, setRedirect] = useState("");
 
-  const { islogin, setIslogin, user } = useContext(UserContext);
+  const { islogin, user } = useContext(UserContext);
   const authToken = localStorage.getItem("token");
   const navigate = useNavigate();
 

--- a/client/src/components/profile/DetailPage.jsx
+++ b/client/src/components/profile/DetailPage.jsx
@@ -13,8 +13,7 @@ export default function PlacePage() {
   const { id } = useParams();
   const [place, setPlace] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
-  const authToken = localStorage.getItem("token");
-  const { islogin, setIslogin, setSelectedChat, setChats, chats } =
+  const { setSelectedChat } =
     useContext(UserContext);
   const navigate = useNavigate();
 

--- a/client/src/components/profile/PhotosUploader.jsx
+++ b/client/src/components/profile/PhotosUploader.jsx
@@ -1,12 +1,9 @@
 import axios from "axios";
-import {useState} from "react";
 import Image from "./Image.jsx";
 import { url } from "../../utils/Constants";
 import swal from "sweetalert";
 
 export default function PhotosUploader({addedPhotos,onChange}) {
-  const [photoLink,setPhotoLink] = useState('');
-
   async function uploadPhoto(ev) {
     try {
       const files = ev.target.files;

--- a/client/src/components/profile/ProfilePage.jsx
+++ b/client/src/components/profile/ProfilePage.jsx
@@ -1,8 +1,7 @@
-import {useContext, useState,useEffect} from "react";
+import {useContext, useEffect} from "react";
 import {UserContext} from "../../context/UserContext.jsx";
 import swal from "sweetalert";
-import {Link, Navigate, useParams,useNavigate} from "react-router-dom";
-import axios from "axios";
+import {useParams,useNavigate} from "react-router-dom";
 import PlacesPage from "./myhosting/PlacesPage";
 import AccountNav from "./AccountNav";
 import "../../assets/styles/profile.css";
@@ -10,7 +9,6 @@ import "../../assets/styles/profile.css";
 
 export default function ProfilePage() {
   const navigate = useNavigate();
-  const [redirect,setRedirect] = useState(null);
   const { islogin,setIslogin,username} = useContext(UserContext);
 
   let {subpage} = useParams();

--- a/client/src/components/profile/bookedhosting/Bookedhosting.jsx
+++ b/client/src/components/profile/bookedhosting/Bookedhosting.jsx
@@ -2,7 +2,7 @@ import AccountNav from "../AccountNav";
 import { useEffect, useState, useContext } from "react";
 import axios from "axios";
 import PlaceImg from "../PlaceImg";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import BookingDates from "../mybooking/BookingDates";
 import { url } from "../../../utils/Constants";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -13,7 +13,7 @@ export default function Bookedhosting() {
   const [bookings, setBookings] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const { islogin, setIslogin, setSelectedChat, setChats, chats } =
+  const { islogin, setSelectedChat } =
     useContext(UserContext);
   const navigate = useNavigate();
 
@@ -84,7 +84,7 @@ export default function Bookedhosting() {
     } else {
       getbookedHostings();
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const accessChat = async (guestuserId) => {
     try {

--- a/client/src/components/profile/mybooking/BookingPage.jsx
+++ b/client/src/components/profile/mybooking/BookingPage.jsx
@@ -16,10 +16,7 @@ export default function BookingPage() {
   const authToken = localStorage.getItem("token");
   const {
     islogin,
-    setIslogin,
     setSelectedChat,
-    setChats,
-    chats,
   } = useContext(UserContext);
   const navigate = useNavigate();
 
@@ -63,7 +60,7 @@ export default function BookingPage() {
     }
     };
     fetchBooking();
-  }, [id]);
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const accessChat = async (guestuserId) => {
     try {

--- a/client/src/components/profile/mybooking/BookingsPage.jsx
+++ b/client/src/components/profile/mybooking/BookingsPage.jsx
@@ -13,7 +13,7 @@ export default function BookingsPage() {
   const [bookings, setBookings] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const { islogin,setIslogin} = useContext(UserContext);
+  const { islogin } = useContext(UserContext);
   const navigate = useNavigate();
 
 
@@ -89,7 +89,7 @@ export default function BookingsPage() {
     } else {
     getBookings();
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="section">

--- a/client/src/components/profile/myhosting/PlacePage.jsx
+++ b/client/src/components/profile/myhosting/PlacePage.jsx
@@ -14,7 +14,7 @@ export default function PlacePage() {
   const [place, setPlace] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const { islogin, setIslogin } = useContext(UserContext);
+  const { islogin } = useContext(UserContext);
   const navigate = useNavigate();
 
   const getuserPlace = async (id) => {
@@ -92,7 +92,7 @@ export default function PlacePage() {
     } else {
       getuserPlace(id);
     }
-  }, [id]);
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isLoading) {
     return (

--- a/client/src/components/profile/myhosting/PlacesFormPage.jsx
+++ b/client/src/components/profile/myhosting/PlacesFormPage.jsx
@@ -23,11 +23,10 @@ export default function PlacesFormPage() {
   const [maxGuests, setMaxGuests] = useState(1);
   const [price, setPrice] = useState(100);
   const [redirect, setRedirect] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const [, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
   const {
     islogin,
-    setIslogin,
     setLatitude,
     latitude,
     longitude,
@@ -75,7 +74,7 @@ export default function PlacesFormPage() {
       }
     };
     fetchPlace();
-  }, [id, islogin]);
+  }, [id, islogin]); // eslint-disable-line react-hooks/exhaustive-deps
   function inputHeader(text) {
     return <h2 className="text-2xl mt-4">{text}</h2>;
   }

--- a/client/src/components/profile/myhosting/PlacesPage.jsx
+++ b/client/src/components/profile/myhosting/PlacesPage.jsx
@@ -1,4 +1,4 @@
-import { Link, useParams, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import AccountNav from "../AccountNav";
 import { useEffect, useState, useContext } from "react";
 import axios from "axios";
@@ -12,7 +12,7 @@ export default function PlacesPage() {
   const [places, setPlaces] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const { islogin, setIslogin } = useContext(UserContext);
+  const { islogin } = useContext(UserContext);
   const navigate = useNavigate();
 
   const getplacesData = async () => {
@@ -51,7 +51,7 @@ export default function PlacesPage() {
     } else {
       getplacesData();
     }
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="section">

--- a/client/src/components/profile/saved/Saved.jsx
+++ b/client/src/components/profile/saved/Saved.jsx
@@ -1,7 +1,7 @@
 import "../../../assets/styles/filter.css";
 import AccountNav from "../AccountNav";
 import React, { useEffect, useState, useContext } from "react";
-import { Link, Navigate, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { url } from "../../../utils/Constants";
 import list from "../../../assets/data/cities.json";
 import { UserContext } from "../../../context/UserContext.jsx";
@@ -12,7 +12,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 function Saved() {
   const [isLoading, setIsLoading] = useState(true);
   const authToken = localStorage.getItem("token");
-  const { islogin, setIslogin } = useContext(UserContext);
+  const { islogin } = useContext(UserContext);
   const navigate = useNavigate();
 
   const [filter, setFilter] = useState({
@@ -47,11 +47,6 @@ function Saved() {
     });
 
     await getData();
-  };
-
-  const removeFilter = async (f) => {
-    setFilterData({ ...filterData, [f]: "" });
-    setFilter({ ...filter, [f]: "" });
   };
 
   //for pagination
@@ -166,7 +161,7 @@ function Saved() {
     } else {
       getData();
     }
-  }, [currentPage, pageSize, filterData]);
+  }, [currentPage, pageSize, filterData]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="section">
@@ -251,8 +246,8 @@ function Saved() {
                     </div> */}
                       <div className="d-flex justify-content-end">
                         <a
-                          href="#"
-                          onClick={handleReset}
+                          href="#!"
+                          onClick={(e) => { e.preventDefault(); handleReset(e); }}
                           className="bg-primary text-white px-4 py-2 rounded"
                         >
                           Reset All

--- a/client/src/context/UserContext.jsx
+++ b/client/src/context/UserContext.jsx
@@ -1,5 +1,4 @@
 import React, { createContext, useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { url } from "../utils/Constants";
 import swal from "sweetalert";
 
@@ -28,8 +27,6 @@ export function UserContextProvider({ children }) {
     address: "",
     placetype: "",
   });
-
-  const history = useNavigate();
 
   //function to verify user
   const checkToken = async () => {

--- a/client/src/layouts/MobileNav.jsx
+++ b/client/src/layouts/MobileNav.jsx
@@ -4,7 +4,7 @@ import {AiOutlineHome} from "react-icons/ai";
 import { RiHotelLine , RiMapPinLine } from "react-icons/ri";
 import { BiMenu} from "react-icons/bi";
 import { BsChatLeftText } from "react-icons/bs";
-import { MdOutlineMeetingRoom,MdFamilyRestroom,MdOutlineLocalHotel } from "react-icons/md";
+import { MdOutlineMeetingRoom,MdOutlineLocalHotel } from "react-icons/md";
 
 const MobileNav = () => {
   return (

--- a/client/src/layouts/Navbar.jsx
+++ b/client/src/layouts/Navbar.jsx
@@ -1,27 +1,22 @@
-import React, { useState, useContext } from "react";
+import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import "../assets/styles/navbar.css";
 import {
-  AiOutlineSearch,
   AiOutlineHome,
-  AiOutlineUser,
-  AiOutlineMenu,
 } from "react-icons/ai";
 import { BsChatLeftText } from "react-icons/bs";
 
-import { RiHotelLine, RiMapPinLine, RiChat1Line } from "react-icons/ri";
+import { RiHotelLine, RiMapPinLine } from "react-icons/ri";
 import { MdOutlineMeetingRoom, MdOutlineLocalHotel } from "react-icons/md";
 import { BiLogIn, BiMenu } from "react-icons/bi";
 import Avatar from "@mui/material/Avatar";
 import { NavLink } from "react-router-dom";
-import { url } from "../utils/Constants";
-import swal from "sweetalert";
 
 import { UserContext } from "../context/UserContext.jsx";
 
 const Navbar = () => {
   const history = useNavigate();
-  const { islogin, setIslogin,user, setUser,username, setUsername ,checkToken } =
+  const { islogin, setIslogin, username, checkToken } =
     useContext(UserContext);
   
 
@@ -168,6 +163,7 @@ const Navbar = () => {
                       <img
                         src={require("../assets/media/images/icon-logout.png")}
                         title="Logout"
+                        alt=""
                       />
                     </a>
                     {/* </div> */}


### PR DESCRIPTION
- Remove unused imports and destructured context vars across 33 files
- Add eslint-disable-line for intentional useEffect dep omissions (Google OAuth init, auth guards, fetch-on-mount patterns)
- Fix jsx-a11y/anchor-is-valid in Room, Flat, Hotel, Saved filter pages
- Fix jsx-a11y/alt-text missing alt on Navbar logout icon
- Remove unused useState/useNavigate/axios/Link imports in profile pages
- Clean up over-destructured UserContext usage in all chat components
- Build now passes with zero warnings (CI=true treats warnings as errors)