### PR TITLE
fix: chat feature - socket stability and message alignment

### DIFF
--- a/client/src/components/chats/ScrollableChat.jsx
+++ b/client/src/components/chats/ScrollableChat.jsx
@@ -1,53 +1,75 @@
 import { Avatar } from "@chakra-ui/avatar";
 import { Tooltip } from "@chakra-ui/tooltip";
 import ScrollableFeed from "react-scrollable-feed";
-import {
-  isLastMessage,
-  isSameSender,
-  isSameSenderMargin,
-  isSameUser,
-} from "./config/ChatLogics";
 import { useContext } from "react";
 import { UserContext } from "../../context/UserContext.jsx";
+
 const ScrollableChat = ({ messages }) => {
-  const {
-    user,
-  } = useContext(UserContext);
+  const { user } = useContext(UserContext);
+
+  if (!user) return null;
 
   return (
     <ScrollableFeed>
       {messages &&
-        messages.map((m, i) => (
-          <div style={{ display: "flex" }} key={m._id}>
-            {(isSameSender(messages, m, i, user._id) ||
-              isLastMessage(messages, i, user._id)) && (
-              <Tooltip label={m.sender.username} placement="bottom-start" hasArrow>
-                <Avatar
-                  mt="7px"
-                  mr={1}
-                  size="sm"
-                  cursor="pointer"
-                  name={m.sender.username}
-                  src={m.sender.pic}
-                />
-              </Tooltip>
-            )}
-            <span
+        messages.map((m, i) => {
+          const isOwn = m.sender._id === user._id;
+          const prevSame = i > 0 && messages[i - 1].sender._id === m.sender._id;
+          const nextSame =
+            i < messages.length - 1 &&
+            messages[i + 1].sender._id === m.sender._id;
+          const showAvatar = !isOwn && !nextSame;
+
+          return (
+            <div
+              key={m._id}
               style={{
-                backgroundColor: `${
-                  m.sender._id === user._id ? "#BEE3F8" : "#B9F5D0"
-                }`,
-                marginLeft: isSameSenderMargin(messages, m, i, user._id),
-                marginTop: isSameUser(messages, m, i, user._id) ? 3 : 10,
-                borderRadius: "20px",
-                padding: "5px 15px",
-                maxWidth: "75%",
+                display: "flex",
+                justifyContent: isOwn ? "flex-end" : "flex-start",
+                alignItems: "flex-end",
+                marginTop: prevSame ? "2px" : "10px",
               }}
             >
-              {m.content}
-            </span>
-          </div>
-        ))}
+              {/* avatar placeholder to keep bubble indented even when avatar hidden */}
+              {!isOwn && (
+                showAvatar ? (
+                  <Tooltip
+                    label={m.sender.username}
+                    placement="bottom-start"
+                    hasArrow
+                  >
+                    <Avatar
+                      mr={1}
+                      size="sm"
+                      cursor="pointer"
+                      name={m.sender.username}
+                      src={m.sender.pic}
+                      flexShrink={0}
+                    />
+                  </Tooltip>
+                ) : (
+                  <span style={{ width: "32px", flexShrink: 0 }} />
+                )
+              )}
+
+              <span
+                style={{
+                  backgroundColor: isOwn ? "#BEE3F8" : "#B9F5D0",
+                  borderRadius: isOwn
+                    ? "18px 18px 4px 18px"
+                    : "18px 18px 18px 4px",
+                  padding: "8px 14px",
+                  maxWidth: "70%",
+                  wordBreak: "break-word",
+                  marginLeft: isOwn ? "0" : "6px",
+                  marginRight: isOwn ? "6px" : "0",
+                }}
+              >
+                {m.content}
+              </span>
+            </div>
+          );
+        })}
     </ScrollableFeed>
   );
 };

--- a/client/src/components/chats/SingleChat.jsx
+++ b/client/src/components/chats/SingleChat.jsx
@@ -18,7 +18,6 @@ import { UserContext } from "../../context/UserContext.jsx";
 import {url} from "../../utils/Constants";
 
 const ENDPOINT = process.env.REACT_APP_API_URL || "https://tolet-roomonrent-server.onrender.com";
-let selectedChatCompare;
 
 const SingleChat = ({ fetchAgain, setFetchAgain }) => {
   const [messages, setMessages] = useState([]);
@@ -30,14 +29,19 @@ const SingleChat = ({ fetchAgain, setFetchAgain }) => {
   const [istyping, setIsTyping] = useState(false);
   const toast = useToast();
   const socketRef = useRef(null);
+  const selectedChatRef = useRef(null);
 
   const {
     selectedChat,
     setSelectedChat,
     user,
-    notification,
     setNotification,
   } = useContext(UserContext);
+
+  // keep ref in sync so socket handler always sees current selectedChat
+  useEffect(() => {
+    selectedChatRef.current = selectedChat;
+  }, [selectedChat]);
 
   const defaultOptions = {
     loop: true,
@@ -56,10 +60,25 @@ const SingleChat = ({ fetchAgain, setFetchAgain }) => {
     socketRef.current.on("connected", () => setSocketConnected(true));
     socketRef.current.on("typing", () => setIsTyping(true));
     socketRef.current.on("stop typing", () => setIsTyping(false));
+    socketRef.current.on("message recieved", (newMessageRecieved) => {
+      if (
+        !selectedChatRef.current ||
+        selectedChatRef.current._id !== newMessageRecieved.chat._id
+      ) {
+        setNotification((prev) =>
+          prev.find((n) => n._id === newMessageRecieved._id)
+            ? prev
+            : [newMessageRecieved, ...prev]
+        );
+        setFetchAgain((prev) => !prev);
+      } else {
+        setMessages((prev) => [...prev, newMessageRecieved]);
+      }
+    });
     return () => {
       socketRef.current.disconnect();
     };
-  }, [user]);
+  }, [user]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchMessages = async () => {
     if (!selectedChat) return;
@@ -130,7 +149,7 @@ const SingleChat = ({ fetchAgain, setFetchAgain }) => {
           `${url}/chats/message`,
           {
             content: newMessage,
-            chatId: selectedChat,
+            chatId: selectedChat._id,
           },
           config
         );
@@ -151,31 +170,8 @@ const SingleChat = ({ fetchAgain, setFetchAgain }) => {
 
   useEffect(() => {
     fetchMessages();
-    selectedChatCompare = selectedChat;
   }, [selectedChat]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (!socketRef.current) return;
-    const handler = (newMessageRecieved) => {
-      if (
-        !selectedChatCompare ||
-        selectedChatCompare._id !== newMessageRecieved.chat._id
-      ) {
-        setNotification((prev) =>
-          prev.find((n) => n._id === newMessageRecieved._id)
-            ? prev
-            : [newMessageRecieved, ...prev]
-        );
-        setFetchAgain((prev) => !prev);
-      } else {
-        setMessages((prev) => [...prev, newMessageRecieved]);
-      }
-    };
-    socketRef.current.on("message recieved", handler);
-    return () => {
-      socketRef.current.off("message recieved", handler);
-    };
-  }, [notification]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>

--- a/client/src/context/UserContext.jsx
+++ b/client/src/context/UserContext.jsx
@@ -45,8 +45,9 @@ export function UserContextProvider({ children }) {
       const json = await response.json();
       if (json.success === true) {
         setIslogin(true);
-        setUser(json);
-        setUsername(String(json.data.firstName + " " + json.data.lastName));
+        if (json.data) {
+          setUsername(String(json.data.firstName + " " + json.data.lastName));
+        }
       } else if(json.success === false){
         setIslogin(false);
         localStorage.removeItem("token");


### PR DESCRIPTION
UserContext: remove setUser() from checkToken() so user._id stays intact after token verification. The verifyuser response has _id nested at data._id, not top-level, causing all socket room joins and sender comparisons to break silently.

SingleChat: consolidate socket 'message recieved' listener into the socket setup effect using selectedChatRef so the handler always sees the current chat without re-registering on every notification change. Remove module-level selectedChatCompare mutable variable. Fix chatId: send selectedChat._id (string) not the full chat object.

ScrollableChat: rewrite message rendering with explicit justifyContent flex-end/flex-start per row so sent messages align right and received messages align left. Show avatar only on the last message in a consecutive group, with a same-width placeholder to keep indentation.